### PR TITLE
Fixed a name

### DIFF
--- a/2018-02-04-prolog02/index.html
+++ b/2018-02-04-prolog02/index.html
@@ -34,7 +34,7 @@ true.
 
 ?-<span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span><span></span></span></code></pre>
 <ul>
-<li>With our facts loaded, we can start asking questions, like “Is Isaac Jacob’s father?”. This would look like this:</li>
+<li>With our facts loaded, we can start asking questions, like “Is Isaac Esau’s father?”. This would look like this:</li>
 </ul>
 <pre class="line-numbers language-bash"><code class="language-bash">?- parent<span class="token punctuation">(</span>isaac, esau<span class="token punctuation">)</span>.
 <span class="token boolean">true</span><span aria-hidden="true" class="line-numbers-rows"><span></span><span></span></span></code></pre>


### PR DESCRIPTION
"Is Isaac Jacob’s father?" changed to "Is Isaac Esau's father?" as shown in the following examples.

Was kind of confusing when reading, as the example didn't match up with the describing text. Could be that I'm seeing this all wrong, might be worth a check.